### PR TITLE
chore: new deployment

### DIFF
--- a/checksums.txt
+++ b/checksums.txt
@@ -1,1 +1,1 @@
-69634072c588ac753919eeac3a6e7808618006e1cac6e03afc046dcfd591ca18  build/release/did-web5-ts
+5833e17f9ec08f1ae320c5434b81ed1cd0bf1635a2844e7878a14c09ddb6c6fb  build/release/did-web5-ts

--- a/deployment/testnet/migrations/2025-07-08-053404.json
+++ b/deployment/testnet/migrations/2025-07-08-053404.json
@@ -1,0 +1,13 @@
+{
+  "cell_recipes": [
+    {
+      "name": "did-web5-ts",
+      "tx_hash": "0x9a1f8ac876408b4c735fb083a3da575b1dc8494b8a422e11ba2561d563d7a84a",
+      "index": 0,
+      "occupied_capacity": 20593400000000,
+      "data_hash": "0x5e16206d951cd36ae89873e6bc50c6a66e9beb5cdd8e694110764b9f3bef768f",
+      "type_id": "0x510150477b10d6ab551a509b71265f3164e9fd4137fcb5a4322f49f03092c7c5"
+    }
+  ],
+  "dep_group_recipes": []
+}


### PR DESCRIPTION
New testnet deployment:

```json
    {
      "name": "did-web5-ts",
      "tx_hash": "0x9a1f8ac876408b4c735fb083a3da575b1dc8494b8a422e11ba2561d563d7a84a",
      "index": 0,
      "occupied_capacity": 20593400000000,
      "data_hash": "0x5e16206d951cd36ae89873e6bc50c6a66e9beb5cdd8e694110764b9f3bef768f",
      "type_id": "0x510150477b10d6ab551a509b71265f3164e9fd4137fcb5a4322f49f03092c7c5"
    }
```
