### PR TITLE
add error unit test

### DIFF
--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 
 [dependencies]
 ckb-did-plc-utils = { path = "../crates/ckb-did-plc-utils" }
+molecule = { version = "0.9.1", default-features = false }

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -287,9 +287,6 @@ impl Read for MockReader {
 
 #[test]
 fn test_molecule_error_invalid_offset() {
-    // 步骤1: 创建无效输入（小缓冲区，但偏移超出）
-    let invalid_data = vec![0u8; 10];  // 有效数据只有10字节
-    // 步骤2: 尝试通过底层 reader 读取无效偏移来触发错误
     let reader = MockReader { total_size: 10, data: vec![0u8; 10] };
     let mut buf = [0u8; 5];
     let result = reader.read(&mut buf, 15);
@@ -303,8 +300,6 @@ fn test_molecule_error_invalid_offset() {
 fn test_reader_error_empty_buffer() {
     // 空缓冲区
     let reader = MockReader { total_size: 0, data: vec![] };
-    let cursor = Cursor::new(0, Box::new(reader));
-
     let reader = MockReader { total_size: 0, data: vec![] };
     let mut buf = [0u8; 1];
     let result = reader.read(&mut buf, 0);

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -15,6 +15,7 @@ use ckb_did_plc_utils::{
         utils::{BufWriter, SliceReader},
     },
     error::Error,
+    reader::validate_cbor_format,
     operation::{validate_2_operations, validate_genesis_operation, validate_operation_history},
 };
 
@@ -324,5 +325,17 @@ fn test_utils_error_invalid_history() {
     let rotation_key_indices = vec![0];  // 长度应为 history.len() + 1 = 2
     let result2 = validate_operation_history(&binary_did, history, rotation_key_indices, &msg, &final_sig);
     assert!(matches!(result2, Err(Error::InvalidHistory)));
+}
+
+#[test]
+fn test_utils_error_invalid_cbor() {
+    // 创建一个无效的 CBOR 数据 Cursor
+    let invalid_cbor_data: Vec<u8> = vec![0x82]; // 无效 CBOR: 期望2个元素的数组但无内容
+    let total_size = invalid_cbor_data.len();
+    let cursor = Cursor::new(total_size, Box::new(MockReader { total_size, data: invalid_cbor_data }));
+
+    let result = validate_cbor_format(cursor);
+
+    assert!(matches!(result, Err(Error::InvalidCbor)));
 }
 

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -16,7 +16,7 @@ use ckb_did_plc_utils::{
     },
     error::Error,
     reader::validate_cbor_format,
-    operation::{validate_2_operations, validate_genesis_operation, validate_operation_history},
+    operation::{validate_2_operations, validate_genesis_operation, validate_operation_history, parse_local_id},
 };
 
 fn test_one_vector(prev_file: &str, cur_file: &str, rotation_key_index: usize) {
@@ -337,5 +337,18 @@ fn test_utils_error_invalid_cbor() {
     let result = validate_cbor_format(cursor);
 
     assert!(matches!(result, Err(Error::InvalidCbor)));
+}
+
+#[test]
+fn test_utils_error_invalid_did_format() {
+    // 测试无效的前缀
+    let invalid_did = b"did:invalid:abc123";
+    let result = parse_local_id(invalid_did);
+    assert!(matches!(result, Err(Error::InvalidDidFormat)));
+
+    // 测试无效的 base32 编码
+    let invalid_base32 = b"did:plc:invalid_base32";
+    let result2 = parse_local_id(invalid_base32);
+    assert!(matches!(result2, Err(Error::InvalidDidFormat)));
 }
 

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -260,10 +260,10 @@ fn test_vector_1_2_wrong_operation_content() {
 }
 #[test]
 fn test_not_genesis_operation() {
-    //只有真正的创世操作（prev 为 null）才能通过验证
-    let non_genesis_path = get_test_vector_path("2-update-handle.cbor"); // 这是一个带有 prev 的更新操作
+    // Only true genesis operations (with prev as null) can pass validation
+    let non_genesis_path = get_test_vector_path("2-update-handle.cbor"); // This is an update operation with prev
     let buf = read(&non_genesis_path).expect("Failed to read file");
-    let binary_did = vec![0u8; 15]; // 任意 DID，实际应匹配
+    let binary_did = vec![0u8; 15]; // Arbitrary DID, should match in practice
     let result = validate_genesis_operation(&buf, &binary_did, 0);
     assert!(matches!(result, Err(Error::NotGenesisOperation)));
 }
@@ -302,7 +302,7 @@ fn test_molecule_error_invalid_offset() {
 
 #[test]
 fn test_molecule_error_empty_buffer() {
-    // 空缓冲区
+    // Empty buffer
     let reader = MockReader {
         total_size: 0,
         data: vec![],
@@ -314,7 +314,7 @@ fn test_molecule_error_empty_buffer() {
 
 #[test]
 fn test_utils_error_invalid_history() {
-    // 步骤1: 创建空历史，触发 InvalidHistory
+    // Step 1: Create empty history to trigger InvalidHistory
     let binary_did = vec![0u8; 15];
     let history: Vec<Cursor> = vec![];
     let rotation_key_indices: Vec<usize> = vec![];
@@ -324,10 +324,10 @@ fn test_utils_error_invalid_history() {
     let result =
         validate_operation_history(&binary_did, history, rotation_key_indices, &msg, &final_sig);
 
-    // 步骤2: 验证返回 UtilsError::InvalidHistory
+    // Step 2: Verify returns UtilsError::InvalidHistory
     assert!(matches!(result, Err(Error::InvalidHistory)));
 
-    // 额外测试: 历史长度与索引不匹配
+    // Additional test: History length does not match indices
     let history = vec![Cursor::new(
         0,
         Box::new(MockReader {
@@ -335,7 +335,7 @@ fn test_utils_error_invalid_history() {
             data: vec![],
         }),
     )];
-    let rotation_key_indices = vec![0]; // 长度应为 history.len() + 1 = 2
+    let rotation_key_indices = vec![0]; // Length should be history.len() + 1 = 2
     let result2 =
         validate_operation_history(&binary_did, history, rotation_key_indices, &msg, &final_sig);
     assert!(matches!(result2, Err(Error::InvalidHistory)));
@@ -343,8 +343,8 @@ fn test_utils_error_invalid_history() {
 
 #[test]
 fn test_utils_error_invalid_cbor() {
-    // 创建一个无效的 CBOR 数据 Cursor
-    let invalid_cbor_data: Vec<u8> = vec![0x82]; // 无效 CBOR: 期望2个元素的数组但无内容
+    // Create an invalid CBOR data Cursor
+    let invalid_cbor_data: Vec<u8> = vec![0x82]; // Invalid CBOR: Expects an array of 2 elements but has no content
     let total_size = invalid_cbor_data.len();
     let cursor = Cursor::new(
         total_size,
@@ -361,12 +361,12 @@ fn test_utils_error_invalid_cbor() {
 
 #[test]
 fn test_utils_error_invalid_did_format() {
-    // 测试无效的前缀
+    // Test invalid prefix
     let invalid_did = b"did:invalid:abc123";
     let result = parse_local_id(invalid_did);
     assert!(matches!(result, Err(Error::InvalidDidFormat)));
 
-    // 测试无效的 base32 编码
+    // Test invalid base32 encoding
     let invalid_base32 = b"did:plc:invalid_base32";
     let result2 = parse_local_id(invalid_base32);
     assert!(matches!(result2, Err(Error::InvalidDidFormat)));

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -268,7 +268,7 @@ fn test_not_genesis_operation() {
     assert!(matches!(result, Err(Error::NotGenesisOperation)));
 }
 
-// 自定义阅读器模拟（基于 molecules.rs 中的 DataReader）
+
 struct MockReader {
     total_size: usize,
     data: Vec<u8>,
@@ -297,12 +297,10 @@ fn test_molecule_error_invalid_offset() {
 }
 
 #[test]
-fn test_reader_error_empty_buffer() {
+fn test_molecule_error_empty_buffer() {
     // 空缓冲区
-    let reader = MockReader { total_size: 0, data: vec![] };
     let reader = MockReader { total_size: 0, data: vec![] };
     let mut buf = [0u8; 1];
     let result = reader.read(&mut buf, 0);
-
     assert!(matches!(result, Err(MoleculeError::OutOfBound(_, _))));
 }

--- a/tests/src/test_vectors.rs
+++ b/tests/src/test_vectors.rs
@@ -256,3 +256,14 @@ fn test_vector_1_2_wrong_operation_content() {
     let result = validate_2_operations(&prev_buf, &cur_buf, 0);
     assert!(matches!(result, Err(Error::VerifySignatureFailed)));
 }
+
+
+#[test]
+fn test_not_genesis_operation() {
+    //只有真正的创世操作（prev 为 null）才能通过验证
+    let non_genesis_path = get_test_vector_path("2-update-handle.cbor");  // 这是一个带有 prev 的更新操作
+    let buf = read(&non_genesis_path).expect("Failed to read file");
+    let binary_did = vec![0u8; 15];  // 任意 DID，实际应匹配
+    let result = validate_genesis_operation(&buf, &binary_did, 0);
+    assert!(matches!(result, Err(Error::NotGenesisOperation)));
+}


### PR DESCRIPTION
support errors cases
- [x] UtilsError::InvalidPrev => 37,
- [x] UtilsError::MissingPrevField => 38,
- [x] UtilsError::NotGenesisOperation => 39,
- [x] UtilsError::DidMismatched => 40,
- [x] UtilsError::ReaderError => 41,
- [x] UtilsError::InvalidKeyIndex => 42,
- [x] UtilsError::InvalidHistory => 43,
- [x] UtilsError::MoleculeError(_) => 44,
- [x] UtilsError::InvalidCbor => 45,
- [x] UtilsError::InvalidDidFormat => 46,

                              
                
              